### PR TITLE
Fix Typo in "Lord Voldemort" Reference Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ It aligns with the ZK vision and will empower individuals globally, regardless o
 
 ![The Collective Action](the-collective-action.jpeg)
 
-ZK Principles empower a network where trust in operators is not needed to secure users' assets and control. Even if the Lord Voldemort had access to our servers, they couldn't harm users' ownership or control their assets.
+ZK Principles empower a network where trust in operators is not needed to secure users' assets and control. Even if Lord Voldemort had access to our servers, he couldn't harm users' ownership or control their assets.
 
 However, technology evolves and so do blockchains. The ZK Principles can’t be fully safeguarded through technology alone. To ensure lasting protection, the community must deeply embrace the elusive concept of decentralization.
 


### PR DESCRIPTION
### Fix Typo in "Lord Voldemort" Reference

In the text, there was a small mistake in the following sentence:

**"Even if the Lord Voldemort had access to our servers, they couldn't harm users' ownership or control their assets."**

The use of "they" is incorrect in this context because it refers to the singular "Lord Voldemort," who is a male character. The correct pronoun should be "he."

### Corrected Version:

**"Even if Lord Voldemort had access to our servers, he couldn't harm users' ownership or control their assets."**

This correction ensures the sentence is grammatically accurate and properly reflects the character reference.

